### PR TITLE
destroy session first on regenerate session when session is active

### DIFF
--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -26,6 +26,7 @@ use function getlastmod;
 use function gmdate;
 use function ini_get;
 use function random_bytes;
+use function session_destroy;
 use function session_id;
 use function session_name;
 use function session_start;
@@ -186,12 +187,13 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
 
     /**
      * Regenerates the session safely.
-     *
-     * @link http://php.net/manual/en/function.session-regenerate-id.php (Example #2)
      */
     private function regenerateSession() : string
     {
-        session_write_close();
+        if (PHP_SESSION_ACTIVE === session_status()) {
+            session_destroy();
+        }
+
         $id = $this->generateSessionId();
         $this->startSession($id, [
             'use_strict_mode' => false,


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

re-create PR for https://github.com/mezzio/mezzio-session-ext/issues/1 . There is a use case when session already started before, and already set some value, eg: on csrf session data on a login form. When authenticate, it call the session regenerate, which session id changed, but left the old session not persisted (unset not applied as session id changed), so old session with the value remain in the disk.

To avoid it, I think we can apply session_destroy() before session_write_close() whenever session is active.