### PR TITLE
Support for the SameSite cookie option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,26 +12,14 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
     - php: 7.4
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -32,19 +32,16 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "ext-session": "*",
-        "dflydev/fig-cookies": "^1.0 || ^2.0",
+        "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-session": "^1.3"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^1.6",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.2 || ^9.0.1"
-    },
-    "conflict": {
-        "phpspec/prophecy": "<1.7.2"
+        "phpunit/phpunit": "^9.0.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

Add support for the `SameSite` SetCookie parameter, described in  RFC6265bis and supported by the `session.cookie_samesite` PHP ini option from PHP 7.3+. The parameter can have the `Lax` or `Strict` or `Null` values, any other value will be ignored.