### PR TITLE
1.9.x use persistence traits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,5 @@
     },
     "replace": {
         "zendframework/zend-expressive-session-ext": "^1.7.0"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^1.6",
-        "phpunit/phpunit": "^9.0.1"
+        "phpunit/phpunit": "9.0.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "ext-session": "*",
         "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
-        "mezzio/mezzio-session": "^1.3"
+        "mezzio/mezzio-session": "^1.4"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
@@ -61,5 +61,7 @@
     },
     "replace": {
         "zendframework/zend-expressive-session-ext": "^1.7.0"
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
Update the php session persistence implementation to use the new persistence traits (cache-header-generator and session-cookie-aware)