### PR TITLE
Add PHP 8 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /clover.xml
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
@@ -18,12 +18,18 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
     - php: 7.4
       env:
         - DEPS=lowest
     - php: 7.4
+      env:
+        - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
+    - php: nightly
+      env:
+        - DEPS=lowest
+    - php: nightly
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "mezzio/mezzio-session": "^1.4"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.1.0",
         "laminas/laminas-diactoros": "^1.6",
         "phpunit/phpunit": "^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ~8.0.0",
         "ext-session": "*",
         "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
@@ -37,7 +37,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^1.6",
-        "phpunit/phpunit": "9.0.*"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas Coding Standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="mezzio-session-ext">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-
-    <php>
-        <ini name="session.save_handler" value="files" />
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="mezzio-session-ext">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="session.save_handler" value="files"/>
+  </php>
 </phpunit>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -11,25 +11,27 @@ declare(strict_types=1);
 namespace Mezzio\Session\Ext;
 
 use Mezzio\Session\SessionPersistenceInterface;
+use Zend\Expressive\Session\Ext\PhpSessionPersistence as LegacyPhpSessionPersistence;
+use Zend\Expressive\Session\SessionPersistenceInterface as LegacySessionPersistenceInterface;
 
 class ConfigProvider
 {
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'dependencies' => $this->getDependencies(),
         ];
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [
-            'aliases' => [
+            'aliases'   => [
                 SessionPersistenceInterface::class => PhpSessionPersistence::class,
 
                 // Legacy Zend Framework aliases
-                \Zend\Expressive\Session\SessionPersistenceInterface::class => SessionPersistenceInterface::class,
-                \Zend\Expressive\Session\Ext\PhpSessionPersistence::class => PhpSessionPersistence::class,
+                LegacySessionPersistenceInterface::class => SessionPersistenceInterface::class,
+                LegacyPhpSessionPersistence::class       => PhpSessionPersistence::class,
             ],
             'factories' => [
                 PhpSessionPersistence::class => PhpSessionPersistenceFactory::class,

--- a/src/PhpSessionPersistence.php
+++ b/src/PhpSessionPersistence.php
@@ -72,7 +72,7 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
      */
     public function __construct(bool $nonLocking = false, bool $deleteCookieOnEmptySession = false)
     {
-        $this->nonLocking = $nonLocking;
+        $this->nonLocking                 = $nonLocking;
         $this->deleteCookieOnEmptySession = $deleteCookieOnEmptySession;
 
         // Get session cache ini settings
@@ -99,14 +99,15 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
 
     /**
      * @internal
+     *
      * @return bool the non-locking mode used during initialization
      */
-    public function isNonLocking() : bool
+    public function isNonLocking(): bool
     {
         return $this->nonLocking;
     }
 
-    public function initializeSessionFromRequest(ServerRequestInterface $request) : SessionInterface
+    public function initializeSessionFromRequest(ServerRequestInterface $request): SessionInterface
     {
         $sessionId = $this->getSessionCookieValueFromRequest($request);
         if ($sessionId) {
@@ -117,14 +118,15 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
         return new Session($_SESSION ?? [], $sessionId);
     }
 
-    public function persistSession(SessionInterface $session, ResponseInterface $response) : ResponseInterface
+    public function persistSession(SessionInterface $session, ResponseInterface $response): ResponseInterface
     {
         $id = $session->getId();
 
         // Regenerate if:
         // - the session is marked as regenerated
         // - the id is empty, but the data has changed (new session)
-        if ($session->isRegenerated()
+        if (
+            $session->isRegenerated()
             || ($id === '' && $session->hasChanged())
         ) {
             $id = $this->regenerateSession();
@@ -156,7 +158,7 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
         return $response;
     }
 
-    public function initializeId(SessionInterface $session) : SessionInterface
+    public function initializeId(SessionInterface $session): SessionInterface
     {
         $id = $session->getId();
         if ($id === '' || $session->isRegenerated()) {
@@ -171,7 +173,7 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
     /**
      * @param array $options Additional options to pass to `session_start()`.
      */
-    private function startSession(string $id, array $options = []) : void
+    private function startSession(string $id, array $options = []): void
     {
         session_id($id);
         session_start([
@@ -184,7 +186,7 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
     /**
      * Regenerates the session safely.
      */
-    private function regenerateSession() : string
+    private function regenerateSession(): string
     {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
@@ -200,7 +202,7 @@ class PhpSessionPersistence implements InitializePersistenceIdInterface, Session
     /**
      * Generate a session identifier.
      */
-    private function generateSessionId() : string
+    private function generateSessionId(): string
     {
         return bin2hex(random_bytes(16));
     }

--- a/src/PhpSessionPersistenceFactory.php
+++ b/src/PhpSessionPersistenceFactory.php
@@ -32,7 +32,7 @@ use Psr\Container\ContainerInterface;
  */
 class PhpSessionPersistenceFactory
 {
-    public function __invoke(ContainerInterface $container) : PhpSessionPersistence
+    public function __invoke(ContainerInterface $container): PhpSessionPersistence
     {
         $config = $container->has('config') ? $container->get('config') : null;
         $config = $config['session']['persistence']['ext'] ?? null;

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -18,12 +18,12 @@ class ConfigProviderTest extends TestCase
     /** @var ConfigProvider */
     private $provider;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->provider = new ConfigProvider();
     }
 
-    public function testInvocationReturnsArray() : array
+    public function testInvocationReturnsArray(): array
     {
         $config = ($this->provider)();
         $this->assertIsArray($config);
@@ -34,7 +34,7 @@ class ConfigProviderTest extends TestCase
     /**
      * @depends testInvocationReturnsArray
      */
-    public function testReturnedArrayContainsDependencies(array $config) : void
+    public function testReturnedArrayContainsDependencies(array $config): void
     {
         $this->assertArrayHasKey('dependencies', $config);
         $this->assertIsArray($config['dependencies']);

--- a/test/PhpSessionPersistenceFactoryTest.php
+++ b/test/PhpSessionPersistenceFactoryTest.php
@@ -66,7 +66,7 @@ class PhpSessionPersistenceFactoryTest extends TestCase
         array $config,
         bool $expected,
         string $methodToTest
-    ) : void {
+    ): void {
         $container = $this->createMock(ContainerInterface::class);
         $factory   = new PhpSessionPersistenceFactory();
 

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -75,7 +75,7 @@ class PhpSessionPersistenceTest extends TestCase
     /** @var string */
     private $sessionSavePath;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->sessionSavePath = sys_get_temp_dir() . '/mezzio-session-ext';
 
@@ -91,7 +91,7 @@ class PhpSessionPersistenceTest extends TestCase
         $this->persistence = new PhpSessionPersistence();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         session_write_close();
         $this->restoreOriginalSessionIniSettings($this->originalSessionSettings);
@@ -105,7 +105,7 @@ class PhpSessionPersistenceTest extends TestCase
         }
     }
 
-    public function startSession(?string $id = null, array $options = []) : void
+    public function startSession(?string $id = null, array $options = []): void
     {
         $id = $id ?: 'testing';
         session_id($id);
@@ -119,7 +119,7 @@ class PhpSessionPersistenceTest extends TestCase
         ?string $sessionId = null,
         ?string $sessionName = null,
         array $serverParams = []
-    ) : ServerRequestInterface {
+    ): ServerRequestInterface {
         return FigRequestCookies::set(
             new ServerRequest($serverParams),
             Cookie::create(
@@ -133,11 +133,11 @@ class PhpSessionPersistenceTest extends TestCase
      * @param array $options Custom session options (without the "session" namespace)
      * @return array Return the original (and overwritten) namespaced ini settings
      */
-    private function applyCustomSessionOptions(array $options) : array
+    private function applyCustomSessionOptions(array $options): array
     {
         $ini = [];
         foreach ($options as $key => $value) {
-            $iniKey = "session.{$key}";
+            $iniKey       = "session.{$key}";
             $ini[$iniKey] = ini_get($iniKey);
             ini_set($iniKey, (string) (is_bool($value) ? (int) $value : $value));
         }
@@ -148,14 +148,14 @@ class PhpSessionPersistenceTest extends TestCase
     /**
      * @param array $ini The original session namespaced ini settings
      */
-    private function restoreOriginalSessionIniSettings(array $ini) : void
+    private function restoreOriginalSessionIniSettings(array $ini): void
     {
         foreach ($ini as $key => $value) {
             ini_set($key, $value);
         }
     }
 
-    private function assertPersistedSessionsCount(int $expectedCount) : void
+    private function assertPersistedSessionsCount(int $expectedCount): void
     {
         $files = glob("{$this->sessionSavePath}/sess_*");
         $this->assertCount($expectedCount, $files);
@@ -202,7 +202,7 @@ class PhpSessionPersistenceTest extends TestCase
         // alter session
         $session->set('foo', 'bar');
 
-        $response = new Response();
+        $response         = new Response();
         $returnedResponse = $this->persistence->persistSession($session, $response);
 
         // check that php-session was started and $session data persisted into it
@@ -221,7 +221,7 @@ class PhpSessionPersistenceTest extends TestCase
     public function testPersistSessionGeneratesCookieWithNewSessionIdIfSessionWasRegenerated()
     {
         $sessionName = 'REGENERATEDSESSID';
-        $ini = $this->applyCustomSessionOptions([
+        $ini         = $this->applyCustomSessionOptions([
             'name' => $sessionName,
         ]);
 
@@ -270,7 +270,7 @@ class PhpSessionPersistenceTest extends TestCase
         $session = $this->persistence->initializeSessionFromRequest($request);
         $session->set('foo', __METHOD__);
 
-        $response = new Response();
+        $response         = new Response();
         $returnedResponse = $this->persistence->persistSession($session, $response);
         $this->assertNotSame($response, $returnedResponse);
 
@@ -291,7 +291,7 @@ class PhpSessionPersistenceTest extends TestCase
     public function testPersistSessionReturnsOriginalResponseIfNoSessionCookiePresent()
     {
         $this->startSession();
-        $session = new Session([]);
+        $session  = new Session([]);
         $response = new Response();
 
         $returnedResponse = $this->persistence->persistSession($session, $response);
@@ -314,8 +314,8 @@ class PhpSessionPersistenceTest extends TestCase
 
         $persistence = new PhpSessionPersistence();
 
-        $request  = $this->createSessionCookieRequest();
-        $session  = $persistence->initializeSessionFromRequest($request);
+        $request = $this->createSessionCookieRequest();
+        $session = $persistence->initializeSessionFromRequest($request);
         $session->set('foo', __METHOD__);
 
         $response = $persistence->persistSession($session, new Response());
@@ -379,8 +379,8 @@ class PhpSessionPersistenceTest extends TestCase
 
         $persistence = new PhpSessionPersistence();
 
-        $request  = $this->createSessionCookieRequest();
-        $session  = $persistence->initializeSessionFromRequest($request);
+        $request = $this->createSessionCookieRequest();
+        $session = $persistence->initializeSessionFromRequest($request);
         $session->set('foo', __METHOD__);
 
         $response = $persistence->persistSession($session, new Response());
@@ -407,8 +407,8 @@ class PhpSessionPersistenceTest extends TestCase
 
         $persistence = new PhpSessionPersistence();
 
-        $request  = $this->createSessionCookieRequest();
-        $session  = $persistence->initializeSessionFromRequest($request);
+        $request = $this->createSessionCookieRequest();
+        $session = $persistence->initializeSessionFromRequest($request);
         $session->set('foo', __METHOD__);
 
         $response = $persistence->persistSession($session, new Response());
@@ -453,13 +453,13 @@ class PhpSessionPersistenceTest extends TestCase
 
         $persistence = new PhpSessionPersistence();
 
-        $request  = $this->createSessionCookieRequest();
-        $session  = $persistence->initializeSessionFromRequest($request);
+        $request = $this->createSessionCookieRequest();
+        $session = $persistence->initializeSessionFromRequest($request);
         $session->set('foo', __METHOD__);
 
         $response = $persistence->persistSession($session, new Response());
 
-        $lastModified = $this->getExpectedLastModified();
+        $lastModified       = $this->getExpectedLastModified();
         $expectedHeaderLine = $lastModified === false ? '' : $lastModified;
 
         $this->assertSame($expectedHeaderLine, $response->getHeaderLine('Last-Modified'));
@@ -511,8 +511,8 @@ class PhpSessionPersistenceTest extends TestCase
     public function testCookiesNotSetWithoutRegenerate()
     {
         $persistence = new PhpSessionPersistence();
-        $request = new ServerRequest();
-        $session = $persistence->initializeSessionFromRequest($request);
+        $request     = new ServerRequest();
+        $session     = $persistence->initializeSessionFromRequest($request);
 
         $response = new Response();
         $response = $persistence->persistSession($session, $response);
@@ -523,8 +523,8 @@ class PhpSessionPersistenceTest extends TestCase
     public function testCookiesSetWithoutRegenerate()
     {
         $persistence = new PhpSessionPersistence();
-        $request = new ServerRequest();
-        $session = $persistence->initializeSessionFromRequest($request);
+        $request     = new ServerRequest();
+        $session     = $persistence->initializeSessionFromRequest($request);
 
         $session->set('foo', 'bar');
 
@@ -534,7 +534,7 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertNotEmpty($response->getHeaderLine('Set-Cookie'));
     }
 
-    public function sameSitePossibleValues()
+    public function sameSitePossibleValues(): array
     {
         return [
             ['Strict'],
@@ -577,8 +577,8 @@ class PhpSessionPersistenceTest extends TestCase
     public function testCookiesSetWithDefaultLifetime()
     {
         $persistence = new PhpSessionPersistence();
-        $request = new ServerRequest();
-        $session = $persistence->initializeSessionFromRequest($request);
+        $request     = new ServerRequest();
+        $session     = $persistence->initializeSessionFromRequest($request);
 
         $session->set('foo', 'bar');
 
@@ -600,13 +600,13 @@ class PhpSessionPersistenceTest extends TestCase
         ]);
 
         $persistence = new PhpSessionPersistence();
-        $request = new ServerRequest();
-        $session = $persistence->initializeSessionFromRequest($request);
+        $request     = new ServerRequest();
+        $session     = $persistence->initializeSessionFromRequest($request);
 
         $session->set('foo', 'bar');
 
         $expiresMin = time() + $lifetime;
-        $response = $persistence->persistSession($session, new Response());
+        $response   = $persistence->persistSession($session, new Response());
         $expiresMax = time() + $lifetime;
 
         $setCookie = FigResponseCookies::get($response, session_name());
@@ -625,14 +625,14 @@ class PhpSessionPersistenceTest extends TestCase
         $originalLifetime = ini_get('session.cookie_lifetime');
 
         $persistence = new PhpSessionPersistence();
-        $request = new ServerRequest();
-        $session = $persistence->initializeSessionFromRequest($request);
+        $request     = new ServerRequest();
+        $session     = $persistence->initializeSessionFromRequest($request);
 
         $lifetime = 300;
         $session->persistSessionFor($lifetime);
 
         $expiresMin = time() + $lifetime;
-        $response = $persistence->persistSession($session, new Response());
+        $response   = $persistence->persistSession($session, new Response());
         $expiresMax = time() + $lifetime;
 
         $setCookie = FigResponseCookies::get($response, session_name());
@@ -654,14 +654,14 @@ class PhpSessionPersistenceTest extends TestCase
         ]);
 
         $persistence = new PhpSessionPersistence();
-        $request = new ServerRequest();
-        $session = $persistence->initializeSessionFromRequest($request);
+        $request     = new ServerRequest();
+        $session     = $persistence->initializeSessionFromRequest($request);
 
         $lifetime = 300;
         $session->persistSessionFor($lifetime);
 
         $expiresMin = time() + $lifetime;
-        $response = $persistence->persistSession($session, new Response());
+        $response   = $persistence->persistSession($session, new Response());
         $expiresMax = time() + $lifetime;
 
         $setCookie = FigResponseCookies::get($response, session_name());
@@ -677,20 +677,20 @@ class PhpSessionPersistenceTest extends TestCase
 
     public function testSavedSessionLifetimeOverridesDefaultLifetime()
     {
-        $ini = $this->applyCustomSessionOptions([
+        $ini      = $this->applyCustomSessionOptions([
             'cookie_lifetime' => 600,
         ]);
         $lifetime = 300;
 
         $persistence = new PhpSessionPersistence();
-        $session = new Session([
+        $session     = new Session([
             SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY => $lifetime,
-            'foo' => 'bar',
+            'foo'                                                   => 'bar',
         ], 'abcdef123456');
         $session->set('foo', __METHOD__);
 
         $expiresMin = time() + $lifetime;
-        $response = $persistence->persistSession($session, new Response());
+        $response   = $persistence->persistSession($session, new Response());
         $expiresMax = time() + $lifetime;
 
         $setCookie = FigResponseCookies::get($response, session_name());
@@ -715,8 +715,8 @@ class PhpSessionPersistenceTest extends TestCase
         $method->invokeArgs($persistence, [
             'my-session-id',
             [
-                'use_cookies'      => true,      // FALSE is required
-                'use_only_cookies' => false,     // TRUE is required
+                'use_cookies'      => true, // FALSE is required
+                'use_only_cookies' => false, // TRUE is required
                 'cache_limiter'    => 'nocache', // '' is required
             ],
         ]);
@@ -736,7 +736,7 @@ class PhpSessionPersistenceTest extends TestCase
     public function testNoMultipleEmptySessionFilesAreCreatedIfNoSessionCookiePresent()
     {
         $sessionName = 'NOSESSIONCOOKIESESSID';
-        $ini = $this->applyCustomSessionOptions([
+        $ini         = $this->applyCustomSessionOptions([
             'name' => $sessionName,
         ]);
 
@@ -758,7 +758,7 @@ class PhpSessionPersistenceTest extends TestCase
                 $setCookie = $setCookies->get($sessionName);
             }
             if (isset($setCookie)) {
-                $cookie = new Cookie($sessionName, $setCookie->getValue());
+                $cookie  = new Cookie($sessionName, $setCookie->getValue());
                 $request = FigRequestCookies::set($request, $cookie);
             }
         }
@@ -771,7 +771,7 @@ class PhpSessionPersistenceTest extends TestCase
     public function testOnlyOneSessionFileIsCreatedIfNoSessionCookiePresentInFirstRequestButSessionDataChanged()
     {
         $sessionName = 'NOSESSIONCOOKIESESSID';
-        $ini = $this->applyCustomSessionOptions([
+        $ini         = $this->applyCustomSessionOptions([
             'name' => $sessionName,
         ]);
 
@@ -781,7 +781,7 @@ class PhpSessionPersistenceTest extends TestCase
         $request = new ServerRequest();
 
         for ($i = 0; $i < 3; ++$i) {
-            $session  = $persistence->initializeSessionFromRequest($request);
+            $session = $persistence->initializeSessionFromRequest($request);
             $session->set('foo' . $i, 'bar' . $i);
             $response = $persistence->persistSession($session, new Response());
 
@@ -794,7 +794,7 @@ class PhpSessionPersistenceTest extends TestCase
                 $setCookie = $setCookies->get($sessionName);
             }
             if (isset($setCookie)) {
-                $cookie = new Cookie($sessionName, $setCookie->getValue());
+                $cookie  = new Cookie($sessionName, $setCookie->getValue());
                 $request = FigRequestCookies::set($request, $cookie);
             }
         }
@@ -806,7 +806,6 @@ class PhpSessionPersistenceTest extends TestCase
 
     /**
      * @dataProvider cookieSettingsProvider
-     *
      * @param string|int|bool $secureIni
      * @param string|int|bool $httpOnlyIni
      */
@@ -876,7 +875,7 @@ class PhpSessionPersistenceTest extends TestCase
         $this->assertSame($_SESSION, $session->toArray());
         $this->assertSame('reloaded-session', session_id());
 
-        $response = new Response();
+        $response         = new Response();
         $returnedResponse = $this->persistence->persistSession($session, $response);
 
         $this->assertSame($returnedResponse, $response, 'returned response should have no cookie and no cache headers');
@@ -939,11 +938,11 @@ class PhpSessionPersistenceTest extends TestCase
         $request = $this->createSessionCookieRequest($sid);
         $session = $persistence->initializeSessionFromRequest($request);
         $session->set($name, $value);
-        $session = $session->regenerate();
+        $session  = $session->regenerate();
         $response = $persistence->persistSession($session, new Response());
 
         // get the regenerated session id from the response session cookie
-        $setCookie = FigResponseCookies::get($response, session_name());
+        $setCookie     = FigResponseCookies::get($response, session_name());
         $regeneratedId = $setCookie->getValue();
 
         $_SESSION = null;
@@ -959,8 +958,8 @@ class PhpSessionPersistenceTest extends TestCase
     public function testInitializeIdReturnsSessionWithId()
     {
         $persistence = new PhpSessionPersistence();
-        $session = new Session(['foo' => 'bar']);
-        $actual = $persistence->initializeId($session);
+        $session     = new Session(['foo' => 'bar']);
+        $actual      = $persistence->initializeId($session);
 
         $this->assertNotSame($session, $actual);
         $this->assertNotEmpty($actual->getId());
@@ -971,9 +970,9 @@ class PhpSessionPersistenceTest extends TestCase
     public function testInitializeIdRegeneratesSessionId()
     {
         $persistence = new PhpSessionPersistence();
-        $session = new Session(['foo' => 'bar'], 'original-id');
-        $session = $session->regenerate();
-        $actual = $persistence->initializeId($session);
+        $session     = new Session(['foo' => 'bar'], 'original-id');
+        $session     = $session->regenerate();
+        $actual      = $persistence->initializeId($session);
 
         $this->assertNotEmpty($actual->getId());
         $this->assertNotSame('original-id', $actual->getId());
@@ -985,7 +984,7 @@ class PhpSessionPersistenceTest extends TestCase
         session_start();
 
         $_SESSION['test'] = 'value';
-        $fileSession = (session_save_path() ?: sys_get_temp_dir()) . '/sess_' . session_id();
+        $fileSession      = (session_save_path() ?: sys_get_temp_dir()) . '/sess_' . session_id();
 
         $this->assertFileExists($fileSession);
 
@@ -1000,11 +999,11 @@ class PhpSessionPersistenceTest extends TestCase
     public function testCookieIsDeletedFromBrowserIfSessionBecomesEmpty()
     {
         $persistence = new PhpSessionPersistence(false, true);
-        $session = new Session(['foo' => 'bar']);
+        $session     = new Session(['foo' => 'bar']);
         $session->clear();
         $response = $persistence->persistSession($session, new Response());
 
-        $cookie = $response->getHeaderLine('Set-Cookie');
+        $cookie   = $response->getHeaderLine('Set-Cookie');
         $expected = 'Expires=Thu, 01 Jan 1970 00:00:01 GMT';
         $this->assertStringContainsString($expected, $cookie, 'cookie should bet set to expire in the past');
     }
@@ -1012,8 +1011,8 @@ class PhpSessionPersistenceTest extends TestCase
     public function testInitializeIdReturnsSessionUnaltered()
     {
         $persistence = new PhpSessionPersistence();
-        $session = new Session(['foo' => 'bar'], 'original-id');
-        $actual = $persistence->initializeId($session);
+        $session     = new Session(['foo' => 'bar'], 'original-id');
+        $actual      = $persistence->initializeId($session);
 
         $this->assertSame($session, $actual);
     }
@@ -1025,9 +1024,9 @@ class PhpSessionPersistenceTest extends TestCase
     {
         $lastmod = getlastmod();
         if ($lastmod === false) {
-            $rc = new ReflectionClass(CacheHeadersGeneratorTrait::class);
+            $rc        = new ReflectionClass(CacheHeadersGeneratorTrait::class);
             $classFile = $rc->getFileName();
-            $lastmod = filemtime($classFile);
+            $lastmod   = filemtime($classFile);
         }
 
         return $lastmod ? gmdate(Http::DATE_FORMAT, $lastmod) : false;

--- a/test/PhpSessionPersistenceTest.php
+++ b/test/PhpSessionPersistenceTest.php
@@ -207,7 +207,7 @@ class PhpSessionPersistenceTest extends TestCase
 
         // check that php-session was started and $session data persisted into it
         $this->assertTrue(isset($_SESSION));
-        $this->assertRegExp('/^[a-f0-9]{32}$/i', session_id());
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{32}$/i', session_id());
         $this->assertSame($session->toArray(), $_SESSION);
 
         // check the returned response
@@ -994,7 +994,7 @@ class PhpSessionPersistenceTest extends TestCase
         $session     = $session->regenerate();
         $persistence->persistSession($session, new Response());
 
-        $this->assertFileNotExists($fileSession);
+        $this->assertFileDoesNotExist($fileSession);
     }
 
     public function testCookieIsDeletedFromBrowserIfSessionBecomesEmpty()


### PR DESCRIPTION
- Adds `~8.0.0` to PHP constraint
- Updates PHPUnit constraint to `^9.3`
- Updates Travis config to add jobs against PHP "nightly"
- Updates tests to use PHPUnit mock objects instead of Prophecy
  - Breaks foreach/assert loops into data providers
- Bumps laminas-coding-standard version to 2.1.0
  - Applies fixes based on phpcbf and phpcs.

Fixes #15
