### PR TITLE
Move "dflydev/fig-cookies" package to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
     "require": {
         "php": "^7.3 || ~8.0.0",
         "ext-session": "*",
-        "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-session": "^1.4"
     },
     "require-dev": {
+        "dflydev/fig-cookies": "^2.0.1 || ^3.0",
         "laminas/laminas-coding-standard": "~2.1.0",
         "laminas/laminas-diactoros": "^1.6",
         "phpunit/phpunit": "^9.3",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

dflydev/fig-cookies is only used in test code. Having it in the production dependencies causes a conflict in consuming packages if they want to use v3 of dflydev/fig-cookies.

also, allow version 3.0 of dflydev/fig-cookies

fixes #19